### PR TITLE
Metals, Java 17

### DIFF
--- a/pwa/.gitignore
+++ b/pwa/.gitignore
@@ -1,4 +1,48 @@
-.idea/
+# initial source provided at https://alvinalexander.com/source-code/scala/sample-gitignore-file-scala-sbt-intellij-eclipse/
+
+# bloop and metals
+.bloop
+.bsp
+
+# metals
+project/metals.sbt
+.metals
+metals.*
+
+# vs code
+.vscode
+
+# scala 3
+.tasty
+
+# sbt
+project/project/
+project/target/
 target/
+
+# eclipse
 build/
-.bsp/
+.classpath
+.project
+.settings
+.worksheet
+bin/
+.cache
+
+# intellij idea
+*.log
+*.iml
+*.ipr
+*.iws
+.idea
+
+# mac
+.DS_Store
+
+# other?
+.history
+.scala_dependencies
+.cache-main
+
+# general
+*.class

--- a/pwa/.sbtopts
+++ b/pwa/.sbtopts
@@ -1,3 +1,2 @@
 -J-Xmx4G
 -J-XX:MaxMetaspaceSize=4G
--J-XX:+CMSClassUnloadingEnabled


### PR DESCRIPTION
updated .gitignore
seems that something does not work with `-J-XX:+CMSClassUnloadingEnabled` removing the line fixed it

```bash
sbt
Unrecognized VM option 'CMSClassUnloadingEnabled'
Error: Could not create the Java Virtual Machine.
Error: A fatal exception has occurred. Program will exit.
copying runtime jar...
mkdir: cannot create directory ‘’: No such file or directory
Unrecognized VM option 'CMSClassUnloadingEnabled'
Error: Could not create the Java Virtual Machine.
Error: A fatal exception has occurred. Program will exit.
Unrecognized VM option 'CMSClassUnloadingEnabled'
Error: Could not create the Java Virtual Machine.
```