### PR TITLE
Remove deprecated store: BestbuyMX

### DIFF
--- a/lib/common/shared/src/main/scala/net/wiringbits/cazadescuentos/common/models/OnlineStore.scala
+++ b/lib/common/shared/src/main/scala/net/wiringbits/cazadescuentos/common/models/OnlineStore.scala
@@ -264,7 +264,6 @@ object OnlineStore {
     HomeDepotMxHttp,
     WalmartMx,
     WalmartMxSuper,
-    BestbuyMx,
     BestbuyUs,
     PalacioDeHierro,
     AmazonMx

--- a/pwa/src/main/scala/net/wiringbits/cazadescuentos/components/pages/HelpPage.scala
+++ b/pwa/src/main/scala/net/wiringbits/cazadescuentos/components/pages/HelpPage.scala
@@ -63,7 +63,6 @@ import scala.scalajs.js
       "https://www.costco.com.mx",
       "https://www.homedepot.com.mx",
       "https://www.walmart.com.mx",
-      "https://www.bestbuy.com.mx",
       "https://www.elpalaciodehierro.com"
     )
 


### PR DESCRIPTION
This Pull request removes `BestBuyMx` from the list of supported stores, as this store [no longer exists](https://www.bestbuy.com.mx/).

It also removes it from the frontend `pwa` project in the `/guia` path.